### PR TITLE
perf(cq): optimize the fk code

### DIFF
--- a/plonkish_backend/src/backend/cq/util.rs
+++ b/plonkish_backend/src/backend/cq/util.rs
@@ -1,5 +1,6 @@
 use halo2_curves::bn256::{Fr, G1Affine, Fq};
 use crate::util::arithmetic::{Field, root_of_unity};
+use std::time::Instant;
 
 type Scalar = Fr;
 
@@ -26,7 +27,10 @@ fn fft_general(values: &mut Vec<Scalar>, inv: bool) -> Vec<Scalar> {
         let R = _fft(&vals.iter().skip(1).step_by(2).cloned().collect::<Vec<_>>(),  &roots_of_unity.iter().step_by(2).cloned().collect::<Vec<_>>());
         let mut o = vec![Fr::from(0); vals.len()];
         for (i, (x, y)) in L.iter().zip(R.iter()).enumerate() {
+            let start = Instant::now();
+            let duration = start.elapsed();
             let y_times_root = *y * roots_of_unity[i];
+            // println!("\n ------------y_times_root: {}ms----------- \n",duration.as_millis());
             o[i] = *x + y_times_root;
             o[i + L.len()] = *x - y_times_root;
         }
@@ -108,12 +112,20 @@ pub fn ec_ifft(values: &mut Vec<G1Affine>) -> Vec<G1Affine> {
 mod tests {
     use super::*;
     use crate::backend::cq::preprocessor::preprocess;
+    use std::time::Instant;
 
     #[test]
     fn test_fft() {
-        let mut values = vec![Fr::from(1), Fr::from(2), Fr::from(3), Fr::from(4)];
+        let mut values = vec![];
+        for k in 1..=2_usize.pow(6) {
+            values.push(Fr::from(k as u64));
+        }
+        // let mut values = vec![Fr::from(1), Fr::from(2), Fr::from(3), Fr::from(4)];
+        let start = Instant::now();
         let mut orig_fft = fft(&mut values);
-        println!("FFT result: {:?}", orig_fft);
+        let duration = start.elapsed();
+        println!("\n ------------fft: {}ms----------- \n",duration.as_millis());
+        // println!("FFT result: {:?}", orig_fft);
 
         let orig_from_ifft = ifft(&mut orig_fft);
         println!("IFFT result: {:?}", orig_from_ifft);


### PR DESCRIPTION
### CQ Code Optimization

After optimizing the code, for a table length of $N = 2^6$ and a lookup size of $n = 4$, the CQ protocol runtime on my computer is as follows:

|                      | Before Optimization | After Optimization |
| -------------------- | ------------------- | ------------------ |
| Setup and preprocess | 4941ms              | 6008ms             |
| Prove                | 16192ms             | 142ms              |
| Verify               | 138ms               | 139ms              |

The optimization mainly focused on two areas:
1. When the Prover calculates $[Q_A(X)]_1$,

<img width="331" alt="image" src="https://github.com/user-attachments/assets/e04a0a8f-99d6-49e6-a016-3291e3695ab9" />


where $\mathsf{supp}(A) := \\{i \in [N]| A_i \neq 0 \\}$, only the parts where $A_i \neq 0$ need to be summed. If $A_i = 0$, it can be skipped. In the previous code, this part was not skipped, causing the Prover to continue performing elliptic curve calculations with $A_i = 0$, resulting in runtime being related to $N$ instead of $n$.

2. All calculations of $[Q_i(X)]_1$ were moved to the precomputation step. When using the FK algorithm for computation, after obtaining the coefficients `q_t_comm_poly_coeffs`, FFT can be directly used for calculation.

```rust
for (i, &a_val) in a_values.iter().enumerate() {
    let mut k_t_comm = group1_zero;
    let mut root = Scalar::one();
    for j in 0..(t as usize) {
        let q_t_coeff = q_t_comm_poly_coeffs[j];
        k_t_comm = (k_t_comm + q_t_coeff * root).into();
        root *= roots[i];
    }
    let scale = roots[i] * (Scalar::from(t as u64).invert().unwrap());
    // Compute Quotient polynomial commitment of T(X)
    let q_t_comm = k_t_comm * scale;
    let a_times_q_t_comm = q_t_comm * a_val;
    q_a_comm_1_fk = (q_a_comm_1_fk + a_times_q_t_comm).into();
}
```

In the original code, the complexity of calculating `k_t_comm` was $O(N^2)$ elliptic curve $\mathbb{G}_1$ operations. After optimization, using `ec_fft` for calculation, the complexity is $O(N\log N) ~ \mathbb{G}_1$.

```rust
let k_t_commit = ec_fft(&mut q_comm_poly_coeffs);

let mut q_t_comm = vec![G1 {x: Fq::zero(), y: Fq::zero(), z: Fq::zero()}; t];
// let start5 = Instant::now();
for i in 0.. t {
    let scale = roots[i] * (Scalar::from(t as u64).invert().unwrap());
    q_t_comm[i] = k_t_commit[i] * scale;
}
```

As can be seen, after optimization, the runtime of the preprocessing stage is still high, mainly due to the FFT and IFFT algorithms on the elliptic curve. The runtime on my computer is as follows:

| CQ           | $N = 2^6, n = 4$ | $N = 2^8, n = 4$ |
| ------------ | ---------------- | ---------------- |
| **Preprocessing** | 6008ms           | 32323ms          |
| ec_fft       | 1824ms           | 9371ms           |
| ec_ifft      | 2257ms           | 11063ms          |
| **Prover**   | 142ms            | 250ms            |
| **Verifier** | 139ms            | 138ms            |

This part has a complexity of $O(N \log N) ~ \mathbb{G}_1$ and takes up a significant portion of the CQ protocol's preprocessing stage.